### PR TITLE
migrate Energia 21

### DIFF
--- a/LSM9DS1.cpp
+++ b/LSM9DS1.cpp
@@ -115,10 +115,7 @@ unsigned char ReadAccLSM9DS1(unsigned char RegAddress)
     Wire.write(RegAddress);
     Wire.endTransmission();
     Wire.requestFrom(LSM9DS1_ADDRESS_MAG, 1);
-    // Wait around until enough data is available
-    while (Wire.available() < 1);
     DataLSM9DS1 = Wire.read();
-    Wire.endTransmission();
   }
   
   return(DataLSM9DS1);
@@ -167,10 +164,7 @@ unsigned char ReadMagLSM9DS1(unsigned char RegAddress)
     Wire.write(RegAddress);
     Wire.endTransmission();
     Wire.requestFrom(LSM9DS1_ADDRESS_MAG, 1);
-    // Wait around until enough data is available
-    while (Wire.available() < 1);
     DataLSM9DS1 = Wire.read();
-    Wire.endTransmission();
   }
   
   return(DataLSM9DS1);
@@ -213,8 +207,7 @@ void ReadAccel(void)
     Wire.write(OUT_X_L_A | JUST_READ);
     Wire.endTransmission();
     Wire.requestFrom(LSM9DS1_ADDRESS_ACCELGYRO, 6);
-    // Wait around until enough data is available
-    while (Wire.available() < 6);
+    
     LSB = Wire.read();
     MSB = Wire.read();
     AccelerationY.Val[0] = LSB;
@@ -231,7 +224,6 @@ void ReadAccel(void)
     MSB = Wire.read();
     AccelerationZ.Val[0] = LSB;
     AccelerationZ.Val[1] = MSB;	
-    Wire.endTransmission();
   }
   // Sign
   AccelerationX.Value = -AccelerationX.Value;
@@ -270,8 +262,6 @@ void ReadGyro(void)
     Wire.write(OUT_X_L_G | JUST_READ);
     Wire.endTransmission();
     Wire.requestFrom(LSM9DS1_ADDRESS_ACCELGYRO, 6);
-    // Wait around until enough data is available
-    while (Wire.available() < 6);
     LSB = Wire.read();
     MSB = Wire.read();
     GyroscopeY.Val[0] = LSB;
@@ -288,7 +278,6 @@ void ReadGyro(void)
     MSB = Wire.read();
     GyroscopeZ.Val[0] = LSB;
     GyroscopeZ.Val[1] = MSB;
-    Wire.endTransmission();
   }
   
   // Sign
@@ -330,8 +319,6 @@ void ReadMagneto(void)
     Wire.write(OUT_X_L_M | JUST_READ);
     Wire.endTransmission();
     Wire.requestFrom(LSM9DS1_ADDRESS_ACCELGYRO, 6);
-    // Wait around until enough data is available
-    while (Wire.available() < 6);
     LSB = Wire.read();
     MSB = Wire.read();
     MagnetometerY.Val[0] = LSB;
@@ -346,7 +333,6 @@ void ReadMagneto(void)
     MSB = Wire.read();
     MagnetometerZ.Val[0] = LSB;
     MagnetometerZ.Val[1] = MSB;
-    Wire.endTransmission();
   }
   // Sign
   MagnetometerX.Value = -MagnetometerX.Value;
@@ -376,13 +362,10 @@ void ReadTemperature(void)
     Wire.write(OUT_TEMP_L | JUST_READ);
     Wire.endTransmission();
     Wire.requestFrom(LSM9DS1_ADDRESS_MAG, 2);
-    // Wait around until enough data is available
-    while (Wire.available() < 2);
     LSB = Wire.read();
     MSB = Wire.read();
     Temperature.Val[0] = LSB;
     Temperature.Val[1] = MSB;	
-    Wire.endTransmission();
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # BITalino R-IoT firmware
 firmware of the BITalino R-IoT Hardware v2.0 (USB charging, USB serial port)
 
+v2.043
+- Couple of fixes on the LSM9DS1 reading
+- migration do Energia 23 for better compatibility (especial on MacOS, now signed software)
+- Discards the use of an external SFLS library, now part of Energia 23
+
+
 v2.041
 - Cosmetics fixes
 - Added a serial message for calibration enabled then disabled after timeout is reached
-- 
 
 v2.04
 - Fixed RGB LED order (swapped green and blue)
@@ -19,21 +24,19 @@ v2.03
 
 #### quick start
 
-* Download and install Energia version 17 from [energia.nu/download/](http://energia.nu/download/#previousreleases).
-* Modify the `cc3200.ld` file and change the `HEAP_SIZE` value to `0x00007500` :
-  * on Windows this file is located into `C:\Program Files(x86)\energia-0101E0017\hardware\cc3200\cores\cc3200`
-  * on Mac OS, right-click on the Energia application and select "show package contents", then go to `Contents/Resources/Java/hardware/cc3200/cores/cc3200`
-* Additionally, the WiFiUdp.cpp source file must be modified (hardware\cc3200\libraries\Wifi), as its function parsePacket() blocks during 10ms. The code has been modified to reduce this timeout to 1ms (change timeout.tv_usec = 1000 instead of 10000)
+* Download and install Energia version 23 from [energia.nu/download/](http://energia.nu/download/).
+* Note : Version 23 now uses the board manager and hardware support isn't located in the Energia folder anymore.
+* Modify the `cc3200.ld` file and change the `HEAP_SIZE` value to `0x00008000` and comment the last line /*PROVIDE(end = _end);*/
+  * on Windows this file is located into `C:\Users\<USER NAME>\AppData\Local\Energia15\packages\energia\hardware\cc3200\1.0.3\cores`
+  * on Mac OS, go on your libraries folder (might be hidden), then go to `Energia15\packages\energia\hardware\cc3200\1.0.3\cores`
+* Additionally, the WiFiUdp.cpp source file must be modified (Energia15\packages\energia\hardware\cc3200\1.0.3\libraries\WiFi), as its function parsePacket() blocks during 10ms. The code has been modified to reduce this timeout to 1ms (change timeout.tv_usec = 1000 instead of 10000)
   to maintain a low latency and a 200Hz update rate of the IMU streaming.
-* We also provide on this git the pre-modified version of Energia 17 (windows and macOS) for an easier start point. Check the root of this git repo.
-* Get the SLFS library from [github.com/Ircam-R-IoT/SLFS](https://github.com/Ircam-R-IoT/SLFS) and drop it into `Documents/Energia/libraries`.
 * Get the BITalino Energia library from [github.com/Ircam-R-IoT/bitalino-energia-library](https://github.com/Ircam-R-IoT/bitalino-energia-library) and drop it into `Documents/Energia/libraries`.
 * Open the firmware.ino file with Energia and hit the "Verify" button in the upper left corner. If it builds, you're ready to upload it to the R-IoT board.
 
 
 #### IMU offsets calibration
-Power up the module *then* within 6 seconds after power up, press the (right most) general purpose switch, the nearest to the RGB led. Keep it pressed for 3 seconds and the module will enter
-calibration mode.
+Power up the module *then* within 6 seconds after power up, press the (right most) general purpose switch, the nearest to the RGB led. Keep it pressed for 3 seconds and the module will enter calibration mode.
 For best practice, the R-IoT can be hooked up to a serial terminal, including the one from Energia. We also use CoolTerm and Docklight, the board uses a 115200 baud rate. 
 Messages are output on the serial port during the calibration to indicate the calibration stages and progress. The RGB led will also wink and blink with various styles to reflect this.
 

--- a/bitalino-riot-firmware.ino
+++ b/bitalino-riot-firmware.ino
@@ -405,7 +405,8 @@ void setup() {
       Serial.print("Setting up Access Point named: ");
       Serial.println(ssidAP);
     }
-    WiFi.beginNetwork((char *)ssidAP);
+    //WiFi.beginNetwork((char *)ssidAP);
+    WiFi.beginNetwork((char *)ssidAP, "12345678");
     WiFi.macAddress(mac);
   }
 
@@ -2319,9 +2320,3 @@ void PrintToOSC(char *StringMessage)
   UdpPacket.endPacket();
   delay(20);
 }
-
-
-
-
-
-

--- a/common.h
+++ b/common.h
@@ -31,7 +31,7 @@
 #define DEFAULT_UDP_PORT  8888
 #define DEFAULT_UDP_SERVICE_PORT  9999
 #define DEFAULT_SAMPLE_RATE  5
-#define VERSION_DATE        "R-IoT Bitalino v2.041 - IRCAM-PLUX 2017-2018"
+#define VERSION_DATE        "R-IoT Bitalino v2.043 - IRCAM-PLUX 2017-2021"
 #define PARAMS_FILENAME     "params.txt"
 #define WEB_SERVER_DELAY    100          // Time to press on the switch to start the webserver      
 


### PR DESCRIPTION
OSX has dropped support for 32-bit applications, including older versions of Energia.

The changes provided support flashing with the latest version of Energia. In addition, the README instrctions have been updated accordingly.